### PR TITLE
修复v-copy指令会重复添加click事件的问题

### DIFF
--- a/src/directives/copy/index.js
+++ b/src/directives/copy/index.js
@@ -1,9 +1,17 @@
 import useClipboard from 'vue-clipboard3'
 import { Message } from '@arco-design/web-vue'
 
+const handlerMap = new WeakMap()
+
 const copy = (el, binding) => {
   const { value } = binding
-  el.addEventListener('click', async () => {
+  
+  const oldHandler = handlerMap.get(el)
+  if (oldHandler) {
+    el.removeEventListener('click', oldHandler)
+  }
+  
+  const newHandler = async () => {
     if (value && value !== '') {
       try {
         await useClipboard().toClipboard(value)
@@ -14,7 +22,11 @@ const copy = (el, binding) => {
     } else {
       throw new Error(`need for copy content! Like v-copy="Hello World"`)
     }
-  })
+  }
+  
+  el.addEventListener('click', newHandler)
+
+  handlerMap.set(el, newHandler)
 }
 
 export default {
@@ -24,4 +36,11 @@ export default {
   updated(el, binding) {
     copy(el, binding)
   },
-};
+  unmounted(el) {
+    const handler = handlerMap.get(el)
+    if (handler) {
+      el.removeEventListener('click', handler)
+      handlerMap.delete(el)
+    }
+  }
+}


### PR DESCRIPTION
修复v-copy指令会重复添加click事件的问题
原问题表现为 点击一次会额外追加一个click事件，导致触发多次复制及提示