### PR TITLE
fix(sa-table):修复sa-table删除的批量处理按钮通过batch控制

### DIFF
--- a/src/components/sa-table/index.vue
+++ b/src/components/sa-table/index.vue
@@ -67,7 +67,7 @@
                 content="确定要删除数据吗?"
                 position="bottom"
                 @ok="deletesMultipleAction"
-                v-if="options.delete.show && options.rowSelection">
+                v-if="options.delete.batch && options.rowSelection">
                 <a-button type="primary" status="danger" v-auth="options.delete.auth || []">
                   <template #icon> <icon-delete /> </template> {{ options.delete.text || '删除' }}
                 </a-button>


### PR DESCRIPTION
### 问题复现
options 配置batch 无效
### 修复内容
 batch可以控制批量删除按钮
